### PR TITLE
perf(zsh): drop ssh completion

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -95,16 +95,13 @@ setopt interactivecomments
 autoload -U select-word-style
 select-word-style bash
 
+zmodload zsh/complist
 autoload -Uz compinit
+compinit
 # End of lines added by compinstall
 
 # menu selection
 zstyle ':completion:*' menu select
-
-# ssh known_hosts completion: http://www.masterzen.fr/2009/04/19/in-love-with-zsh-part-one/
-# The directive HashKnownHosts must be No
-hosts=($((( [ -r .ssh/known_hosts ] && awk '{print $1}' .ssh/known_hosts | tr , '\n'); ) | sort -u) )
-zstyle ':completion:*' hosts $hosts
 
 #########
 # aliases


### PR DESCRIPTION
Il me semble que c'est pris en charge par le système.

Preuve: `/usr/share/zsh/5.5.1/functions/*ssh*`

Validé sur RH
A tester sur Ubuntu